### PR TITLE
Fixed enum namespace collision.

### DIFF
--- a/Source/UnrealFastNoisePlugin/Public/FastNoise/FastNoise.h
+++ b/Source/UnrealFastNoisePlugin/Public/FastNoise/FastNoise.h
@@ -75,7 +75,7 @@ enum ECellularDistanceFunction { Euclidean, Manhattan, Natural };
 UENUM(BlueprintType)
 enum ECellularReturnType { CellValue, NoiseLookup, Distance, Distance2, Distance2Add, Distance2Sub, Distance2Mul, Distance2Div};
 UENUM(BlueprintType)
-enum EPositionWarpType { None, Regular, Fractal };
+enum class EPositionWarpType : uint8 { None, Regular, Fractal };
 UENUM(BlueprintType)
 enum class ESelectInterpType : uint8
 {


### PR DESCRIPTION
Enum `EPositionWarpType` value `None` collided with other enum as the namespace was global. Changed it to enum class.

It's important because it produces a build error. And whenever there is a build error, you cannot cook a build.

It's up to you to update the rest of enums if you like :)
Thank you for this plugin!